### PR TITLE
Add Program & Template schemas (Milestone 3)

### DIFF
--- a/examples/invalid/program-empty-weeks.json
+++ b/examples/invalid/program-empty-weeks.json
@@ -1,0 +1,4 @@
+{
+  "name": "Program With Empty Weeks",
+  "weeks": []
+}

--- a/examples/invalid/program-missing-weeks.json
+++ b/examples/invalid/program-missing-weeks.json
@@ -1,0 +1,4 @@
+{
+  "name": "Program Without Weeks",
+  "description": "This program is missing the required weeks array"
+}

--- a/examples/invalid/template-empty-exercises.json
+++ b/examples/invalid/template-empty-exercises.json
@@ -1,0 +1,4 @@
+{
+  "name": "Empty Template",
+  "exercises": []
+}

--- a/examples/invalid/template-missing-name.json
+++ b/examples/invalid/template-missing-name.json
@@ -1,0 +1,8 @@
+{
+  "exercises": [
+    {
+      "exercise": { "name": "Bench Press" },
+      "sets": [{ "targetReps": 5 }]
+    }
+  ]
+}

--- a/examples/invalid/template-weight-without-unit.json
+++ b/examples/invalid/template-weight-without-unit.json
@@ -1,0 +1,9 @@
+{
+  "name": "Template Without Unit",
+  "exercises": [
+    {
+      "exercise": { "name": "Bench Press" },
+      "sets": [{ "targetWeight": 100 }]
+    }
+  ]
+}

--- a/examples/programs/531-bbb.json
+++ b/examples/programs/531-bbb.json
@@ -1,0 +1,452 @@
+{
+  "name": "5/3/1 Boring But Big",
+  "description": "Jim Wendler's 5/3/1 program with Boring But Big supplemental work. A 4-week cycle focusing on the four main lifts with 5x10 volume work.",
+  "author": "Jim Wendler",
+  "tags": ["strength", "powerlifting", "intermediate"],
+  "weeks": [
+    {
+      "name": "Week 1 - 3x5",
+      "notes": "Working sets at 65%, 75%, 85% of training max",
+      "workouts": [
+        {
+          "name": "Squat Day",
+          "day": 1,
+          "exercises": [
+            {
+              "exercise": { "name": "Barbell Back Squat", "equipment": "barbell", "category": "legs" },
+              "order": 1,
+              "sets": [
+                { "type": "working", "targetReps": 5, "percentage": 65, "percentageOf": "1RM", "restSeconds": 180 },
+                { "type": "working", "targetReps": 5, "percentage": 75, "percentageOf": "1RM", "restSeconds": 180 },
+                { "type": "working", "targetReps": 5, "percentage": 85, "percentageOf": "1RM", "notes": "AMRAP", "restSeconds": 180 }
+              ]
+            },
+            {
+              "exercise": { "name": "Barbell Back Squat", "equipment": "barbell", "category": "legs" },
+              "order": 2,
+              "notes": "BBB sets",
+              "sets": [
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 }
+              ]
+            },
+            {
+              "exercise": { "name": "Leg Curl", "equipment": "machine", "category": "legs" },
+              "order": 3,
+              "sets": [
+                { "targetRepsMin": 10, "targetRepsMax": 15 },
+                { "targetRepsMin": 10, "targetRepsMax": 15 },
+                { "targetRepsMin": 10, "targetRepsMax": 15 }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Bench Day",
+          "day": 2,
+          "exercises": [
+            {
+              "exercise": { "name": "Barbell Bench Press", "equipment": "barbell", "category": "chest" },
+              "order": 1,
+              "sets": [
+                { "type": "working", "targetReps": 5, "percentage": 65, "percentageOf": "1RM", "restSeconds": 180 },
+                { "type": "working", "targetReps": 5, "percentage": 75, "percentageOf": "1RM", "restSeconds": 180 },
+                { "type": "working", "targetReps": 5, "percentage": 85, "percentageOf": "1RM", "notes": "AMRAP", "restSeconds": 180 }
+              ]
+            },
+            {
+              "exercise": { "name": "Barbell Bench Press", "equipment": "barbell", "category": "chest" },
+              "order": 2,
+              "notes": "BBB sets",
+              "sets": [
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 }
+              ]
+            },
+            {
+              "exercise": { "name": "Dumbbell Row", "equipment": "dumbbell", "category": "back" },
+              "order": 3,
+              "sets": [
+                { "targetRepsMin": 10, "targetRepsMax": 15 },
+                { "targetRepsMin": 10, "targetRepsMax": 15 },
+                { "targetRepsMin": 10, "targetRepsMax": 15 }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Deadlift Day",
+          "day": 4,
+          "exercises": [
+            {
+              "exercise": { "name": "Deadlift", "equipment": "barbell", "category": "back" },
+              "order": 1,
+              "sets": [
+                { "type": "working", "targetReps": 5, "percentage": 65, "percentageOf": "1RM", "restSeconds": 180 },
+                { "type": "working", "targetReps": 5, "percentage": 75, "percentageOf": "1RM", "restSeconds": 180 },
+                { "type": "working", "targetReps": 5, "percentage": 85, "percentageOf": "1RM", "notes": "AMRAP", "restSeconds": 180 }
+              ]
+            },
+            {
+              "exercise": { "name": "Deadlift", "equipment": "barbell", "category": "back" },
+              "order": 2,
+              "notes": "BBB sets",
+              "sets": [
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 }
+              ]
+            },
+            {
+              "exercise": { "name": "Hanging Leg Raise", "equipment": "bodyweight", "category": "core" },
+              "order": 3,
+              "sets": [
+                { "targetRepsMin": 10, "targetRepsMax": 15 },
+                { "targetRepsMin": 10, "targetRepsMax": 15 },
+                { "targetRepsMin": 10, "targetRepsMax": 15 }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Overhead Press Day",
+          "day": 5,
+          "exercises": [
+            {
+              "exercise": { "name": "Overhead Press", "equipment": "barbell", "category": "shoulders" },
+              "order": 1,
+              "sets": [
+                { "type": "working", "targetReps": 5, "percentage": 65, "percentageOf": "1RM", "restSeconds": 180 },
+                { "type": "working", "targetReps": 5, "percentage": 75, "percentageOf": "1RM", "restSeconds": 180 },
+                { "type": "working", "targetReps": 5, "percentage": 85, "percentageOf": "1RM", "notes": "AMRAP", "restSeconds": 180 }
+              ]
+            },
+            {
+              "exercise": { "name": "Overhead Press", "equipment": "barbell", "category": "shoulders" },
+              "order": 2,
+              "notes": "BBB sets",
+              "sets": [
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 }
+              ]
+            },
+            {
+              "exercise": { "name": "Chin-up", "equipment": "bodyweight", "category": "back" },
+              "order": 3,
+              "sets": [
+                { "targetRepsMin": 8, "targetRepsMax": 12 },
+                { "targetRepsMin": 8, "targetRepsMax": 12 },
+                { "targetRepsMin": 8, "targetRepsMax": 12 }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Week 2 - 3x3",
+      "notes": "Working sets at 70%, 80%, 90% of training max",
+      "workouts": [
+        {
+          "name": "Squat Day",
+          "day": 1,
+          "exercises": [
+            {
+              "exercise": { "name": "Barbell Back Squat", "equipment": "barbell", "category": "legs" },
+              "order": 1,
+              "sets": [
+                { "type": "working", "targetReps": 3, "percentage": 70, "percentageOf": "1RM", "restSeconds": 180 },
+                { "type": "working", "targetReps": 3, "percentage": 80, "percentageOf": "1RM", "restSeconds": 180 },
+                { "type": "working", "targetReps": 3, "percentage": 90, "percentageOf": "1RM", "notes": "AMRAP", "restSeconds": 180 }
+              ]
+            },
+            {
+              "exercise": { "name": "Barbell Back Squat", "equipment": "barbell", "category": "legs" },
+              "order": 2,
+              "notes": "BBB sets",
+              "sets": [
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Bench Day",
+          "day": 2,
+          "exercises": [
+            {
+              "exercise": { "name": "Barbell Bench Press", "equipment": "barbell", "category": "chest" },
+              "order": 1,
+              "sets": [
+                { "type": "working", "targetReps": 3, "percentage": 70, "percentageOf": "1RM", "restSeconds": 180 },
+                { "type": "working", "targetReps": 3, "percentage": 80, "percentageOf": "1RM", "restSeconds": 180 },
+                { "type": "working", "targetReps": 3, "percentage": 90, "percentageOf": "1RM", "notes": "AMRAP", "restSeconds": 180 }
+              ]
+            },
+            {
+              "exercise": { "name": "Barbell Bench Press", "equipment": "barbell", "category": "chest" },
+              "order": 2,
+              "notes": "BBB sets",
+              "sets": [
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Deadlift Day",
+          "day": 4,
+          "exercises": [
+            {
+              "exercise": { "name": "Deadlift", "equipment": "barbell", "category": "back" },
+              "order": 1,
+              "sets": [
+                { "type": "working", "targetReps": 3, "percentage": 70, "percentageOf": "1RM", "restSeconds": 180 },
+                { "type": "working", "targetReps": 3, "percentage": 80, "percentageOf": "1RM", "restSeconds": 180 },
+                { "type": "working", "targetReps": 3, "percentage": 90, "percentageOf": "1RM", "notes": "AMRAP", "restSeconds": 180 }
+              ]
+            },
+            {
+              "exercise": { "name": "Deadlift", "equipment": "barbell", "category": "back" },
+              "order": 2,
+              "notes": "BBB sets",
+              "sets": [
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Overhead Press Day",
+          "day": 5,
+          "exercises": [
+            {
+              "exercise": { "name": "Overhead Press", "equipment": "barbell", "category": "shoulders" },
+              "order": 1,
+              "sets": [
+                { "type": "working", "targetReps": 3, "percentage": 70, "percentageOf": "1RM", "restSeconds": 180 },
+                { "type": "working", "targetReps": 3, "percentage": 80, "percentageOf": "1RM", "restSeconds": 180 },
+                { "type": "working", "targetReps": 3, "percentage": 90, "percentageOf": "1RM", "notes": "AMRAP", "restSeconds": 180 }
+              ]
+            },
+            {
+              "exercise": { "name": "Overhead Press", "equipment": "barbell", "category": "shoulders" },
+              "order": 2,
+              "notes": "BBB sets",
+              "sets": [
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Week 3 - 5/3/1",
+      "notes": "Working sets at 75%, 85%, 95% of training max",
+      "workouts": [
+        {
+          "name": "Squat Day",
+          "day": 1,
+          "exercises": [
+            {
+              "exercise": { "name": "Barbell Back Squat", "equipment": "barbell", "category": "legs" },
+              "order": 1,
+              "sets": [
+                { "type": "working", "targetReps": 5, "percentage": 75, "percentageOf": "1RM", "restSeconds": 180 },
+                { "type": "working", "targetReps": 3, "percentage": 85, "percentageOf": "1RM", "restSeconds": 180 },
+                { "type": "working", "targetReps": 1, "percentage": 95, "percentageOf": "1RM", "notes": "AMRAP", "restSeconds": 180 }
+              ]
+            },
+            {
+              "exercise": { "name": "Barbell Back Squat", "equipment": "barbell", "category": "legs" },
+              "order": 2,
+              "notes": "BBB sets",
+              "sets": [
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Bench Day",
+          "day": 2,
+          "exercises": [
+            {
+              "exercise": { "name": "Barbell Bench Press", "equipment": "barbell", "category": "chest" },
+              "order": 1,
+              "sets": [
+                { "type": "working", "targetReps": 5, "percentage": 75, "percentageOf": "1RM", "restSeconds": 180 },
+                { "type": "working", "targetReps": 3, "percentage": 85, "percentageOf": "1RM", "restSeconds": 180 },
+                { "type": "working", "targetReps": 1, "percentage": 95, "percentageOf": "1RM", "notes": "AMRAP", "restSeconds": 180 }
+              ]
+            },
+            {
+              "exercise": { "name": "Barbell Bench Press", "equipment": "barbell", "category": "chest" },
+              "order": 2,
+              "notes": "BBB sets",
+              "sets": [
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Deadlift Day",
+          "day": 4,
+          "exercises": [
+            {
+              "exercise": { "name": "Deadlift", "equipment": "barbell", "category": "back" },
+              "order": 1,
+              "sets": [
+                { "type": "working", "targetReps": 5, "percentage": 75, "percentageOf": "1RM", "restSeconds": 180 },
+                { "type": "working", "targetReps": 3, "percentage": 85, "percentageOf": "1RM", "restSeconds": 180 },
+                { "type": "working", "targetReps": 1, "percentage": 95, "percentageOf": "1RM", "notes": "AMRAP", "restSeconds": 180 }
+              ]
+            },
+            {
+              "exercise": { "name": "Deadlift", "equipment": "barbell", "category": "back" },
+              "order": 2,
+              "notes": "BBB sets",
+              "sets": [
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Overhead Press Day",
+          "day": 5,
+          "exercises": [
+            {
+              "exercise": { "name": "Overhead Press", "equipment": "barbell", "category": "shoulders" },
+              "order": 1,
+              "sets": [
+                { "type": "working", "targetReps": 5, "percentage": 75, "percentageOf": "1RM", "restSeconds": 180 },
+                { "type": "working", "targetReps": 3, "percentage": 85, "percentageOf": "1RM", "restSeconds": 180 },
+                { "type": "working", "targetReps": 1, "percentage": 95, "percentageOf": "1RM", "notes": "AMRAP", "restSeconds": 180 }
+              ]
+            },
+            {
+              "exercise": { "name": "Overhead Press", "equipment": "barbell", "category": "shoulders" },
+              "order": 2,
+              "notes": "BBB sets",
+              "sets": [
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+                { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Week 4 - Deload",
+      "notes": "Recovery week at 40%, 50%, 60% of training max",
+      "workouts": [
+        {
+          "name": "Squat Day",
+          "day": 1,
+          "exercises": [
+            {
+              "exercise": { "name": "Barbell Back Squat", "equipment": "barbell", "category": "legs" },
+              "order": 1,
+              "sets": [
+                { "targetReps": 5, "percentage": 40, "percentageOf": "1RM", "restSeconds": 120 },
+                { "targetReps": 5, "percentage": 50, "percentageOf": "1RM", "restSeconds": 120 },
+                { "targetReps": 5, "percentage": 60, "percentageOf": "1RM", "restSeconds": 120 }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Bench Day",
+          "day": 2,
+          "exercises": [
+            {
+              "exercise": { "name": "Barbell Bench Press", "equipment": "barbell", "category": "chest" },
+              "order": 1,
+              "sets": [
+                { "targetReps": 5, "percentage": 40, "percentageOf": "1RM", "restSeconds": 120 },
+                { "targetReps": 5, "percentage": 50, "percentageOf": "1RM", "restSeconds": 120 },
+                { "targetReps": 5, "percentage": 60, "percentageOf": "1RM", "restSeconds": 120 }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Deadlift Day",
+          "day": 4,
+          "exercises": [
+            {
+              "exercise": { "name": "Deadlift", "equipment": "barbell", "category": "back" },
+              "order": 1,
+              "sets": [
+                { "targetReps": 5, "percentage": 40, "percentageOf": "1RM", "restSeconds": 120 },
+                { "targetReps": 5, "percentage": 50, "percentageOf": "1RM", "restSeconds": 120 },
+                { "targetReps": 5, "percentage": 60, "percentageOf": "1RM", "restSeconds": 120 }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Overhead Press Day",
+          "day": 5,
+          "exercises": [
+            {
+              "exercise": { "name": "Overhead Press", "equipment": "barbell", "category": "shoulders" },
+              "order": 1,
+              "sets": [
+                { "targetReps": 5, "percentage": 40, "percentageOf": "1RM", "restSeconds": 120 },
+                { "targetReps": 5, "percentage": 50, "percentageOf": "1RM", "restSeconds": 120 },
+                { "targetReps": 5, "percentage": 60, "percentageOf": "1RM", "restSeconds": 120 }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/examples/programs/minimal.json
+++ b/examples/programs/minimal.json
@@ -1,0 +1,35 @@
+{
+  "name": "Simple 2-Day Split",
+  "weeks": [
+    {
+      "workouts": [
+        {
+          "name": "Workout A",
+          "exercises": [
+            {
+              "exercise": { "name": "Squat" },
+              "sets": [{ "targetReps": 5 }, { "targetReps": 5 }, { "targetReps": 5 }]
+            },
+            {
+              "exercise": { "name": "Bench Press" },
+              "sets": [{ "targetReps": 5 }, { "targetReps": 5 }, { "targetReps": 5 }]
+            }
+          ]
+        },
+        {
+          "name": "Workout B",
+          "exercises": [
+            {
+              "exercise": { "name": "Deadlift" },
+              "sets": [{ "targetReps": 5 }, { "targetReps": 5 }, { "targetReps": 5 }]
+            },
+            {
+              "exercise": { "name": "Overhead Press" },
+              "sets": [{ "targetReps": 5 }, { "targetReps": 5 }, { "targetReps": 5 }]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/examples/workout-templates/full-featured.json
+++ b/examples/workout-templates/full-featured.json
@@ -1,0 +1,78 @@
+{
+  "name": "Upper Body A",
+  "notes": "Focus on compound pushing movements with accessory work",
+  "day": 1,
+  "exercises": [
+    {
+      "exercise": {
+        "name": "Barbell Bench Press",
+        "equipment": "barbell",
+        "category": "chest",
+        "musclesWorked": ["pectoralis major", "anterior deltoid", "triceps"]
+      },
+      "order": 1,
+      "notes": "Pause at chest, drive feet into floor",
+      "sets": [
+        { "type": "warmup", "targetReps": 10, "percentage": 50, "percentageOf": "1RM" },
+        { "type": "warmup", "targetReps": 5, "percentage": 70, "percentageOf": "1RM" },
+        { "type": "working", "targetReps": 5, "percentage": 85, "percentageOf": "1RM", "targetRPE": 8, "restSeconds": 180 },
+        { "type": "working", "targetReps": 5, "percentage": 85, "percentageOf": "1RM", "targetRPE": 8, "restSeconds": 180 },
+        { "type": "working", "targetReps": 5, "percentage": 85, "percentageOf": "1RM", "targetRPE": 8, "restSeconds": 180 }
+      ]
+    },
+    {
+      "exercise": {
+        "name": "Overhead Press",
+        "equipment": "barbell",
+        "category": "shoulders"
+      },
+      "order": 2,
+      "sets": [
+        { "targetReps": 8, "targetWeight": 60, "unit": "kg", "targetRPE": 7, "restSeconds": 120 },
+        { "targetReps": 8, "targetWeight": 60, "unit": "kg", "targetRPE": 7, "restSeconds": 120 },
+        { "targetReps": 8, "targetWeight": 60, "unit": "kg", "targetRPE": 7, "restSeconds": 120 }
+      ]
+    },
+    {
+      "exercise": {
+        "name": "Dumbbell Row",
+        "equipment": "dumbbell",
+        "category": "back"
+      },
+      "order": 3,
+      "supersetId": 1,
+      "sets": [
+        { "targetRepsMin": 8, "targetRepsMax": 12, "targetRIR": 2 },
+        { "targetRepsMin": 8, "targetRepsMax": 12, "targetRIR": 2 },
+        { "targetRepsMin": 8, "targetRepsMax": 12, "targetRIR": 2 }
+      ]
+    },
+    {
+      "exercise": {
+        "name": "Dumbbell Lateral Raise",
+        "equipment": "dumbbell",
+        "category": "shoulders"
+      },
+      "order": 4,
+      "supersetId": 1,
+      "sets": [
+        { "targetRepsMin": 12, "targetRepsMax": 15, "tempo": "2-0-2-1" },
+        { "targetRepsMin": 12, "targetRepsMax": 15, "tempo": "2-0-2-1" },
+        { "targetRepsMin": 12, "targetRepsMax": 15, "tempo": "2-0-2-1" }
+      ]
+    },
+    {
+      "exercise": {
+        "name": "Tricep Pushdown",
+        "equipment": "cable",
+        "category": "arms"
+      },
+      "order": 5,
+      "sets": [
+        { "targetRepsMin": 10, "targetRepsMax": 15, "targetRIR": 1 },
+        { "targetRepsMin": 10, "targetRepsMax": 15, "targetRIR": 1 },
+        { "type": "dropset", "targetReps": 10, "notes": "Drop weight 20%, continue to failure" }
+      ]
+    }
+  ]
+}

--- a/examples/workout-templates/minimal.json
+++ b/examples/workout-templates/minimal.json
@@ -1,0 +1,13 @@
+{
+  "name": "Push Day",
+  "exercises": [
+    {
+      "exercise": { "name": "Bench Press" },
+      "sets": [
+        { "targetReps": 5 },
+        { "targetReps": 5 },
+        { "targetReps": 5 }
+      ]
+    }
+  ]
+}

--- a/examples/workout-templates/percentage-based.json
+++ b/examples/workout-templates/percentage-based.json
@@ -1,0 +1,64 @@
+{
+  "name": "531 Week 1 Squat Day",
+  "notes": "Wendler 5/3/1 week 1 - 3x5 at 65/75/85%",
+  "exercises": [
+    {
+      "exercise": {
+        "name": "Barbell Back Squat",
+        "equipment": "barbell",
+        "category": "legs"
+      },
+      "order": 1,
+      "sets": [
+        { "type": "warmup", "targetReps": 5, "percentage": 40, "percentageOf": "1RM" },
+        { "type": "warmup", "targetReps": 5, "percentage": 50, "percentageOf": "1RM" },
+        { "type": "warmup", "targetReps": 3, "percentage": 60, "percentageOf": "1RM" },
+        { "type": "working", "targetReps": 5, "percentage": 65, "percentageOf": "1RM", "restSeconds": 180 },
+        { "type": "working", "targetReps": 5, "percentage": 75, "percentageOf": "1RM", "restSeconds": 180 },
+        { "type": "working", "targetReps": 5, "percentage": 85, "percentageOf": "1RM", "notes": "AMRAP on last set", "restSeconds": 180 }
+      ]
+    },
+    {
+      "exercise": {
+        "name": "Barbell Back Squat",
+        "equipment": "barbell",
+        "category": "legs"
+      },
+      "order": 2,
+      "notes": "BBB supplemental - 5x10 at 50%",
+      "sets": [
+        { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+        { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+        { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+        { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 },
+        { "targetReps": 10, "percentage": 50, "percentageOf": "1RM", "restSeconds": 90 }
+      ]
+    },
+    {
+      "exercise": {
+        "name": "Leg Curl",
+        "equipment": "machine",
+        "category": "legs"
+      },
+      "order": 3,
+      "sets": [
+        { "targetRepsMin": 10, "targetRepsMax": 15 },
+        { "targetRepsMin": 10, "targetRepsMax": 15 },
+        { "targetRepsMin": 10, "targetRepsMax": 15 }
+      ]
+    },
+    {
+      "exercise": {
+        "name": "Ab Wheel Rollout",
+        "equipment": "bodyweight",
+        "category": "core"
+      },
+      "order": 4,
+      "sets": [
+        { "targetRepsMin": 10, "targetRepsMax": 20 },
+        { "targetRepsMin": 10, "targetRepsMax": 20 },
+        { "targetRepsMin": 10, "targetRepsMax": 20 }
+      ]
+    }
+  ]
+}

--- a/packages/ts-sdk/src/index.ts
+++ b/packages/ts-sdk/src/index.ts
@@ -1,21 +1,55 @@
+// Types
 export type {
-  WorkoutLog,
-  ExerciseLog,
-  Exercise,
-  SetLog,
+  // Common types
   WeightUnit,
   DistanceUnit,
+  Exercise,
+  // Workout Log types
+  WorkoutLog,
+  ExerciseLog,
+  SetLog,
+  // Workout Template types
+  WorkoutTemplate,
+  ExerciseTemplate,
+  SetTemplate,
+  // Program types
+  Program,
+  ProgramWeek,
 } from './types.js'
 
-export { parseWorkoutLog, ParseError } from './parse.js'
+// Parse functions
+export {
+  parseWorkoutLog,
+  parseWorkoutTemplate,
+  parseProgram,
+  ParseError,
+} from './parse.js'
 
-export { serializeWorkoutLog, serializeWorkoutLogPretty } from './serialize.js'
+// Serialize functions
+export {
+  serializeWorkoutLog,
+  serializeWorkoutLogPretty,
+  serializeWorkoutTemplate,
+  serializeWorkoutTemplatePretty,
+  serializeProgram,
+  serializeProgramPretty,
+} from './serialize.js'
 
+// Validate functions
 export {
   validateWorkoutLog,
   isValidWorkoutLog,
+  validateWorkoutTemplate,
+  isValidWorkoutTemplate,
+  validateProgram,
+  isValidProgram,
   type ValidationResult,
   type ValidationError,
 } from './validate.js'
 
-export { workoutLogSchema } from './schema.js'
+// Schemas
+export {
+  workoutLogSchema,
+  workoutTemplateSchema,
+  programSchema,
+} from './schema.js'

--- a/packages/ts-sdk/src/parse.test.ts
+++ b/packages/ts-sdk/src/parse.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { parseWorkoutLog, ParseError } from './parse.js'
+import { parseWorkoutLog, parseWorkoutTemplate, parseProgram, ParseError } from './parse.js'
 
 const validJson = JSON.stringify({
   date: '2024-01-15T09:00:00Z',
@@ -49,5 +49,79 @@ describe('parseWorkoutLog', () => {
     })
     const result = parseWorkoutLog(json)
     expect(result['app:customField']).toBe('value')
+  })
+})
+
+// ============================================
+// Workout Template Parsing Tests
+// ============================================
+
+const validTemplateJson = JSON.stringify({
+  name: 'Push Day',
+  exercises: [
+    {
+      exercise: { name: 'Bench Press' },
+      sets: [{ targetReps: 5 }],
+    },
+  ],
+})
+
+describe('parseWorkoutTemplate', () => {
+  it('parses valid template JSON', () => {
+    const result = parseWorkoutTemplate(validTemplateJson)
+    expect(result.name).toBe('Push Day')
+    expect(result.exercises).toHaveLength(1)
+    expect(result.exercises[0].exercise.name).toBe('Bench Press')
+  })
+
+  it('throws ParseError for invalid JSON syntax', () => {
+    expect(() => parseWorkoutTemplate('not json')).toThrow(ParseError)
+  })
+
+  it('throws ParseError for schema validation failures', () => {
+    const invalidJson = JSON.stringify({ name: 'Test' })
+    expect(() => parseWorkoutTemplate(invalidJson)).toThrow(ParseError)
+  })
+})
+
+// ============================================
+// Program Parsing Tests
+// ============================================
+
+const validProgramJson = JSON.stringify({
+  name: 'Simple Program',
+  weeks: [
+    {
+      workouts: [
+        {
+          name: 'Day 1',
+          exercises: [
+            {
+              exercise: { name: 'Squat' },
+              sets: [{ targetReps: 5 }],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+})
+
+describe('parseProgram', () => {
+  it('parses valid program JSON', () => {
+    const result = parseProgram(validProgramJson)
+    expect(result.name).toBe('Simple Program')
+    expect(result.weeks).toHaveLength(1)
+    expect(result.weeks[0].workouts).toHaveLength(1)
+    expect(result.weeks[0].workouts[0].name).toBe('Day 1')
+  })
+
+  it('throws ParseError for invalid JSON syntax', () => {
+    expect(() => parseProgram('not json')).toThrow(ParseError)
+  })
+
+  it('throws ParseError for schema validation failures', () => {
+    const invalidJson = JSON.stringify({ name: 'Test' })
+    expect(() => parseProgram(invalidJson)).toThrow(ParseError)
   })
 })

--- a/packages/ts-sdk/src/parse.ts
+++ b/packages/ts-sdk/src/parse.ts
@@ -1,5 +1,5 @@
-import { validateWorkoutLog } from './validate.js'
-import type { WorkoutLog } from './types.js'
+import { validateWorkoutLog, validateWorkoutTemplate, validateProgram } from './validate.js'
+import type { WorkoutLog, WorkoutTemplate, Program } from './types.js'
 
 export class ParseError extends Error {
   constructor(
@@ -10,6 +10,10 @@ export class ParseError extends Error {
     this.name = 'ParseError'
   }
 }
+
+// ============================================
+// Workout Log Parsing
+// ============================================
 
 export function parseWorkoutLog(json: string): WorkoutLog {
   let data: unknown
@@ -25,4 +29,44 @@ export function parseWorkoutLog(json: string): WorkoutLog {
   }
 
   return data as WorkoutLog
+}
+
+// ============================================
+// Workout Template Parsing
+// ============================================
+
+export function parseWorkoutTemplate(json: string): WorkoutTemplate {
+  let data: unknown
+  try {
+    data = JSON.parse(json)
+  } catch {
+    throw new ParseError('Invalid JSON')
+  }
+
+  const result = validateWorkoutTemplate(data)
+  if (!result.valid) {
+    throw new ParseError('Schema validation failed', result.errors)
+  }
+
+  return data as WorkoutTemplate
+}
+
+// ============================================
+// Program Parsing
+// ============================================
+
+export function parseProgram(json: string): Program {
+  let data: unknown
+  try {
+    data = JSON.parse(json)
+  } catch {
+    throw new ParseError('Invalid JSON')
+  }
+
+  const result = validateProgram(data)
+  if (!result.valid) {
+    throw new ParseError('Schema validation failed', result.errors)
+  }
+
+  return data as Program
 }

--- a/packages/ts-sdk/src/schema.ts
+++ b/packages/ts-sdk/src/schema.ts
@@ -1,3 +1,7 @@
+// ============================================
+// Workout Log Schema
+// ============================================
+
 export const workoutLogSchema = {
   $schema: 'http://json-schema.org/draft-07/schema#',
   $id: 'https://openweight.org/schemas/workout-log.schema.json',
@@ -30,6 +34,12 @@ export const workoutLogSchema = {
       description: 'Total workout duration in seconds',
       type: 'integer',
       minimum: 0,
+    },
+    templateId: {
+      title: 'Template ID',
+      description: 'Optional reference to the workout template this log was created from',
+      type: 'string',
+      maxLength: 200,
     },
     exercises: {
       title: 'Exercises',
@@ -211,6 +221,312 @@ export const workoutLogSchema = {
           description: 'Notes for this specific set',
           type: 'string',
           maxLength: 1000,
+        },
+      },
+    },
+  },
+} as const
+
+// ============================================
+// Workout Template Schema
+// ============================================
+
+export const workoutTemplateSchema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  $id: 'https://openweight.org/schemas/workout-template.schema.json',
+  title: 'WorkoutTemplate',
+  description: 'A planned workout with target sets and reps',
+  type: 'object',
+  required: ['name', 'exercises'],
+  additionalProperties: true,
+  properties: {
+    name: {
+      title: 'Name',
+      description: 'Name of the workout template',
+      type: 'string',
+      minLength: 1,
+      maxLength: 200,
+    },
+    notes: {
+      title: 'Notes',
+      description: 'Notes about the workout template',
+      type: 'string',
+      maxLength: 10000,
+    },
+    day: {
+      title: 'Day',
+      description: 'Day of the week (1=Monday, 7=Sunday)',
+      type: 'integer',
+      minimum: 1,
+      maximum: 7,
+    },
+    exercises: {
+      title: 'Exercises',
+      description: 'The exercises in this workout template',
+      type: 'array',
+      minItems: 1,
+      items: {
+        $ref: '#/definitions/ExerciseTemplate',
+      },
+    },
+  },
+  definitions: {
+    ExerciseTemplate: {
+      title: 'ExerciseTemplate',
+      description: 'A planned exercise with target sets',
+      type: 'object',
+      required: ['exercise', 'sets'],
+      additionalProperties: true,
+      properties: {
+        exercise: {
+          $ref: '#/definitions/Exercise',
+        },
+        order: {
+          title: 'Order',
+          description: 'Position in workout (1-indexed)',
+          type: 'integer',
+          minimum: 1,
+        },
+        notes: {
+          title: 'Notes',
+          description: 'Notes specific to this exercise',
+          type: 'string',
+          maxLength: 5000,
+        },
+        supersetId: {
+          title: 'Superset ID',
+          description: 'Groups exercises into supersets',
+          type: 'integer',
+          minimum: 1,
+        },
+        sets: {
+          title: 'Sets',
+          description: 'The target sets for this exercise',
+          type: 'array',
+          minItems: 1,
+          items: {
+            $ref: '#/definitions/SetTemplate',
+          },
+        },
+      },
+    },
+    Exercise: {
+      title: 'Exercise',
+      description: 'Describes which exercise to perform',
+      type: 'object',
+      required: ['name'],
+      additionalProperties: true,
+      properties: {
+        name: {
+          title: 'Name',
+          description: 'Human-readable exercise name',
+          type: 'string',
+          minLength: 1,
+          maxLength: 200,
+        },
+        equipment: {
+          title: 'Equipment',
+          description: 'Equipment used',
+          type: 'string',
+          maxLength: 50,
+        },
+        category: {
+          title: 'Category',
+          description: 'Body part or category',
+          type: 'string',
+          maxLength: 50,
+        },
+        musclesWorked: {
+          title: 'Muscles Worked',
+          description: 'Specific muscles targeted',
+          type: 'array',
+          items: {
+            type: 'string',
+            maxLength: 50,
+          },
+        },
+      },
+    },
+    SetTemplate: {
+      title: 'SetTemplate',
+      description: 'A target set with prescribed reps, weight, and intensity',
+      type: 'object',
+      additionalProperties: true,
+      allOf: [
+        {
+          if: { required: ['targetWeight'] },
+          then: { required: ['unit'] },
+        },
+        {
+          if: { required: ['percentage'] },
+          then: { required: ['percentageOf'] },
+        },
+      ],
+      properties: {
+        targetReps: {
+          title: 'Target Reps',
+          description: 'Exact number of reps to perform',
+          type: 'integer',
+          minimum: 0,
+        },
+        targetRepsMin: {
+          title: 'Target Reps (Min)',
+          description: 'Minimum reps in a rep range',
+          type: 'integer',
+          minimum: 0,
+        },
+        targetRepsMax: {
+          title: 'Target Reps (Max)',
+          description: 'Maximum reps in a rep range',
+          type: 'integer',
+          minimum: 0,
+        },
+        targetWeight: {
+          title: 'Target Weight',
+          description: 'Absolute weight to use',
+          type: 'number',
+          minimum: 0,
+        },
+        unit: {
+          title: 'Unit',
+          description: 'Weight unit. Required if targetWeight is provided.',
+          type: 'string',
+          enum: ['kg', 'lb'],
+        },
+        percentage: {
+          title: 'Percentage',
+          description: 'Percentage of a reference weight',
+          type: 'number',
+          minimum: 0,
+          maximum: 200,
+        },
+        percentageOf: {
+          title: 'Percentage Of',
+          description: 'Reference for percentage (e.g., 1RM)',
+          type: 'string',
+          maxLength: 50,
+        },
+        targetRPE: {
+          title: 'Target RPE',
+          description: 'Target Rate of Perceived Exertion (0-10)',
+          type: 'number',
+          minimum: 0,
+          maximum: 10,
+        },
+        targetRIR: {
+          title: 'Target RIR',
+          description: 'Target Reps In Reserve',
+          type: 'integer',
+          minimum: 0,
+        },
+        restSeconds: {
+          title: 'Rest (seconds)',
+          description: 'Recommended rest after this set',
+          type: 'integer',
+          minimum: 0,
+        },
+        tempo: {
+          title: 'Tempo',
+          description: 'Tempo notation: eccentric-pause-concentric-pause',
+          type: 'string',
+          pattern: '^[0-9X]-[0-9X]-[0-9X]-[0-9X]$',
+        },
+        type: {
+          title: 'Type',
+          description: 'Set type (working, warmup, dropset, etc.)',
+          type: 'string',
+          maxLength: 50,
+        },
+        notes: {
+          title: 'Notes',
+          description: 'Notes for this set',
+          type: 'string',
+          maxLength: 1000,
+        },
+      },
+    },
+  },
+} as const
+
+// ============================================
+// Program Schema
+// ============================================
+
+export const programSchema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  $id: 'https://openweight.org/schemas/program.schema.json',
+  title: 'Program',
+  description: 'A structured training program consisting of multiple weeks of workouts',
+  type: 'object',
+  required: ['name', 'weeks'],
+  additionalProperties: true,
+  properties: {
+    name: {
+      title: 'Name',
+      description: 'Name of the training program',
+      type: 'string',
+      minLength: 1,
+      maxLength: 200,
+    },
+    description: {
+      title: 'Description',
+      description: 'Detailed description of the program',
+      type: 'string',
+      maxLength: 50000,
+    },
+    author: {
+      title: 'Author',
+      description: 'Creator or source of the program',
+      type: 'string',
+      maxLength: 200,
+    },
+    tags: {
+      title: 'Tags',
+      description: 'Categories or labels for the program',
+      type: 'array',
+      items: {
+        type: 'string',
+        maxLength: 50,
+      },
+    },
+    weeks: {
+      title: 'Weeks',
+      description: 'The weeks that make up this program',
+      type: 'array',
+      minItems: 1,
+      items: {
+        $ref: '#/definitions/ProgramWeek',
+      },
+    },
+  },
+  definitions: {
+    ProgramWeek: {
+      title: 'ProgramWeek',
+      description: 'A week of training within a program',
+      type: 'object',
+      required: ['workouts'],
+      additionalProperties: true,
+      properties: {
+        name: {
+          title: 'Name',
+          description: 'Name or label for this week',
+          type: 'string',
+          maxLength: 200,
+        },
+        notes: {
+          title: 'Notes',
+          description: 'Notes or instructions for this week',
+          type: 'string',
+          maxLength: 10000,
+        },
+        workouts: {
+          title: 'Workouts',
+          description: 'The workout templates for this week',
+          type: 'array',
+          minItems: 1,
+          items: {
+            $ref: 'workout-template.schema.json',
+          },
         },
       },
     },

--- a/packages/ts-sdk/src/serialize.ts
+++ b/packages/ts-sdk/src/serialize.ts
@@ -1,4 +1,8 @@
-import type { WorkoutLog } from './types.js'
+import type { WorkoutLog, WorkoutTemplate, Program } from './types.js'
+
+// ============================================
+// Workout Log Serialization
+// ============================================
 
 export function serializeWorkoutLog(workout: WorkoutLog): string {
   return JSON.stringify(workout)
@@ -6,4 +10,28 @@ export function serializeWorkoutLog(workout: WorkoutLog): string {
 
 export function serializeWorkoutLogPretty(workout: WorkoutLog): string {
   return JSON.stringify(workout, null, 2)
+}
+
+// ============================================
+// Workout Template Serialization
+// ============================================
+
+export function serializeWorkoutTemplate(template: WorkoutTemplate): string {
+  return JSON.stringify(template)
+}
+
+export function serializeWorkoutTemplatePretty(template: WorkoutTemplate): string {
+  return JSON.stringify(template, null, 2)
+}
+
+// ============================================
+// Program Serialization
+// ============================================
+
+export function serializeProgram(program: Program): string {
+  return JSON.stringify(program)
+}
+
+export function serializeProgramPretty(program: Program): string {
+  return JSON.stringify(program, null, 2)
 }

--- a/packages/ts-sdk/src/types.ts
+++ b/packages/ts-sdk/src/types.ts
@@ -2,6 +2,10 @@ export type WeightUnit = 'kg' | 'lb'
 
 export type DistanceUnit = 'm' | 'km' | 'ft' | 'mi' | 'yd'
 
+// ============================================
+// Workout Log Types (completed workouts)
+// ============================================
+
 export interface SetLog {
   reps?: number
   weight?: number
@@ -42,5 +46,64 @@ export interface WorkoutLog {
   name?: string
   notes?: string
   durationSeconds?: number
+  templateId?: string
+  [key: string]: unknown
+}
+
+// ============================================
+// Workout Template Types (planned workouts)
+// ============================================
+
+export interface SetTemplate {
+  targetReps?: number
+  targetRepsMin?: number
+  targetRepsMax?: number
+  targetWeight?: number
+  unit?: WeightUnit
+  percentage?: number
+  percentageOf?: string
+  targetRPE?: number
+  targetRIR?: number
+  restSeconds?: number
+  tempo?: string
+  type?: string
+  notes?: string
+  [key: string]: unknown
+}
+
+export interface ExerciseTemplate {
+  exercise: Exercise
+  sets: SetTemplate[]
+  order?: number
+  notes?: string
+  supersetId?: number
+  [key: string]: unknown
+}
+
+export interface WorkoutTemplate {
+  name: string
+  exercises: ExerciseTemplate[]
+  notes?: string
+  day?: number
+  [key: string]: unknown
+}
+
+// ============================================
+// Program Types (multi-week training programs)
+// ============================================
+
+export interface ProgramWeek {
+  workouts: WorkoutTemplate[]
+  name?: string
+  notes?: string
+  [key: string]: unknown
+}
+
+export interface Program {
+  name: string
+  weeks: ProgramWeek[]
+  description?: string
+  author?: string
+  tags?: string[]
   [key: string]: unknown
 }

--- a/packages/ts-sdk/src/validate.ts
+++ b/packages/ts-sdk/src/validate.ts
@@ -1,7 +1,7 @@
 import Ajv from 'ajv'
 import addFormats from 'ajv-formats'
-import { workoutLogSchema } from './schema.js'
-import type { WorkoutLog } from './types.js'
+import { workoutLogSchema, workoutTemplateSchema, programSchema } from './schema.js'
+import type { WorkoutLog, WorkoutTemplate, Program } from './types.js'
 
 export interface ValidationError {
   path: string
@@ -16,23 +16,70 @@ export interface ValidationResult {
 const ajv = new Ajv({ allErrors: true })
 addFormats(ajv)
 
-const validateSchema = ajv.compile(workoutLogSchema)
+// Add workout template schema first (referenced by program)
+ajv.addSchema(workoutTemplateSchema)
+
+const validateWorkoutLogSchema = ajv.compile(workoutLogSchema)
+const validateWorkoutTemplateSchema = ajv.compile(workoutTemplateSchema)
+const validateProgramSchema = ajv.compile(programSchema)
+
+function formatErrors(errors: typeof validateWorkoutLogSchema.errors): ValidationError[] {
+  return (errors ?? []).map((err) => ({
+    path: err.instancePath || '/',
+    message: err.message ?? 'Unknown validation error',
+  }))
+}
+
+// ============================================
+// Workout Log Validation
+// ============================================
 
 export function validateWorkoutLog(data: unknown): ValidationResult {
-  const valid = validateSchema(data)
+  const valid = validateWorkoutLogSchema(data)
 
   if (valid) {
     return { valid: true, errors: [] }
   }
 
-  const errors: ValidationError[] = (validateSchema.errors ?? []).map((err) => ({
-    path: err.instancePath || '/',
-    message: err.message ?? 'Unknown validation error',
-  }))
-
-  return { valid: false, errors }
+  return { valid: false, errors: formatErrors(validateWorkoutLogSchema.errors) }
 }
 
 export function isValidWorkoutLog(data: unknown): data is WorkoutLog {
-  return validateSchema(data)
+  return validateWorkoutLogSchema(data)
+}
+
+// ============================================
+// Workout Template Validation
+// ============================================
+
+export function validateWorkoutTemplate(data: unknown): ValidationResult {
+  const valid = validateWorkoutTemplateSchema(data)
+
+  if (valid) {
+    return { valid: true, errors: [] }
+  }
+
+  return { valid: false, errors: formatErrors(validateWorkoutTemplateSchema.errors) }
+}
+
+export function isValidWorkoutTemplate(data: unknown): data is WorkoutTemplate {
+  return validateWorkoutTemplateSchema(data)
+}
+
+// ============================================
+// Program Validation
+// ============================================
+
+export function validateProgram(data: unknown): ValidationResult {
+  const valid = validateProgramSchema(data)
+
+  if (valid) {
+    return { valid: true, errors: [] }
+  }
+
+  return { valid: false, errors: formatErrors(validateProgramSchema.errors) }
+}
+
+export function isValidProgram(data: unknown): data is Program {
+  return validateProgramSchema(data)
 }

--- a/schemas/program.schema.json
+++ b/schemas/program.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://openweight.org/schemas/program.schema.json",
+  "title": "Program",
+  "description": "A structured training program consisting of multiple weeks of workouts",
+  "type": "object",
+  "required": ["name", "weeks"],
+  "additionalProperties": true,
+  "properties": {
+    "name": {
+      "title": "Name",
+      "description": "Name of the training program",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200,
+      "examples": ["Starting Strength", "5/3/1 BBB", "GZCLP"]
+    },
+    "description": {
+      "title": "Description",
+      "description": "Detailed description of the program, its goals, and how to follow it",
+      "type": "string",
+      "maxLength": 50000
+    },
+    "author": {
+      "title": "Author",
+      "description": "Creator or source of the program",
+      "type": "string",
+      "maxLength": 200,
+      "examples": ["Mark Rippetoe", "Jim Wendler", "Cody Lefever"]
+    },
+    "tags": {
+      "title": "Tags",
+      "description": "Categories or labels for the program",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "maxLength": 50
+      },
+      "examples": [["strength", "beginner"], ["powerlifting", "intermediate"]]
+    },
+    "weeks": {
+      "title": "Weeks",
+      "description": "The weeks that make up this program",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/ProgramWeek"
+      }
+    }
+  },
+  "definitions": {
+    "ProgramWeek": {
+      "title": "ProgramWeek",
+      "description": "A week of training within a program",
+      "type": "object",
+      "required": ["workouts"],
+      "additionalProperties": true,
+      "properties": {
+        "name": {
+          "title": "Name",
+          "description": "Name or label for this week",
+          "type": "string",
+          "maxLength": 200,
+          "examples": ["Week 1", "Deload Week", "5s Week"]
+        },
+        "notes": {
+          "title": "Notes",
+          "description": "Notes or instructions for this week",
+          "type": "string",
+          "maxLength": 10000
+        },
+        "workouts": {
+          "title": "Workouts",
+          "description": "The workout templates for this week",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "workout-template.schema.json"
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/workout-log.schema.json
+++ b/schemas/workout-log.schema.json
@@ -34,6 +34,12 @@
       "minimum": 0,
       "examples": [3600, 5400]
     },
+    "templateId": {
+      "title": "Template ID",
+      "description": "Optional reference to the workout template this log was created from. App-defined identifier.",
+      "type": "string",
+      "maxLength": 200
+    },
     "exercises": {
       "title": "Exercises",
       "description": "The exercises performed in this workout",

--- a/schemas/workout-template.schema.json
+++ b/schemas/workout-template.schema.json
@@ -1,0 +1,231 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://openweight.org/schemas/workout-template.schema.json",
+  "title": "WorkoutTemplate",
+  "description": "A planned workout with target sets and reps",
+  "type": "object",
+  "required": ["name", "exercises"],
+  "additionalProperties": true,
+  "properties": {
+    "name": {
+      "title": "Name",
+      "description": "Name of the workout template",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200,
+      "examples": ["Push Day", "Upper Body A", "Leg Day"]
+    },
+    "notes": {
+      "title": "Notes",
+      "description": "Notes about the workout template",
+      "type": "string",
+      "maxLength": 10000
+    },
+    "day": {
+      "title": "Day",
+      "description": "Day of the week (1=Monday, 7=Sunday). Optional scheduling hint.",
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 7
+    },
+    "exercises": {
+      "title": "Exercises",
+      "description": "The exercises in this workout template",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/ExerciseTemplate"
+      }
+    }
+  },
+  "definitions": {
+    "ExerciseTemplate": {
+      "title": "ExerciseTemplate",
+      "description": "A planned exercise with target sets",
+      "type": "object",
+      "required": ["exercise", "sets"],
+      "additionalProperties": true,
+      "properties": {
+        "exercise": {
+          "$ref": "#/definitions/Exercise"
+        },
+        "order": {
+          "title": "Order",
+          "description": "Position in workout (1-indexed). If omitted, array order is used.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "notes": {
+          "title": "Notes",
+          "description": "Notes specific to this exercise",
+          "type": "string",
+          "maxLength": 5000
+        },
+        "supersetId": {
+          "title": "Superset ID",
+          "description": "Groups exercises into supersets. Same ID = same superset.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "sets": {
+          "title": "Sets",
+          "description": "The target sets for this exercise",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/SetTemplate"
+          }
+        }
+      }
+    },
+    "Exercise": {
+      "title": "Exercise",
+      "description": "Describes which exercise to perform",
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": true,
+      "properties": {
+        "name": {
+          "title": "Name",
+          "description": "Human-readable exercise name",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200,
+          "examples": ["Barbell Back Squat", "Bench Press", "Pull-up"]
+        },
+        "equipment": {
+          "title": "Equipment",
+          "description": "Equipment used",
+          "type": "string",
+          "maxLength": 50,
+          "examples": ["barbell", "dumbbell", "bodyweight"]
+        },
+        "category": {
+          "title": "Category",
+          "description": "Body part or category",
+          "type": "string",
+          "maxLength": 50,
+          "examples": ["chest", "back", "legs"]
+        },
+        "musclesWorked": {
+          "title": "Muscles Worked",
+          "description": "Specific muscles targeted by this exercise",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "maxLength": 50
+          }
+        }
+      }
+    },
+    "SetTemplate": {
+      "title": "SetTemplate",
+      "description": "A target set with prescribed reps, weight, and intensity",
+      "type": "object",
+      "additionalProperties": true,
+      "allOf": [
+        {
+          "if": { "required": ["targetWeight"] },
+          "then": { "required": ["unit"] }
+        },
+        {
+          "if": { "required": ["percentage"] },
+          "then": { "required": ["percentageOf"] }
+        }
+      ],
+      "properties": {
+        "targetReps": {
+          "title": "Target Reps",
+          "description": "Exact number of reps to perform",
+          "type": "integer",
+          "minimum": 0,
+          "examples": [5, 8, 12]
+        },
+        "targetRepsMin": {
+          "title": "Target Reps (Min)",
+          "description": "Minimum reps in a rep range",
+          "type": "integer",
+          "minimum": 0,
+          "examples": [8, 10]
+        },
+        "targetRepsMax": {
+          "title": "Target Reps (Max)",
+          "description": "Maximum reps in a rep range",
+          "type": "integer",
+          "minimum": 0,
+          "examples": [12, 15]
+        },
+        "targetWeight": {
+          "title": "Target Weight",
+          "description": "Absolute weight to use",
+          "type": "number",
+          "minimum": 0,
+          "examples": [100, 60.5, 225]
+        },
+        "unit": {
+          "title": "Unit",
+          "description": "Weight unit. Required if targetWeight is provided.",
+          "type": "string",
+          "enum": ["kg", "lb"]
+        },
+        "percentage": {
+          "title": "Percentage",
+          "description": "Percentage of a reference weight (e.g., 80% of 1RM)",
+          "type": "number",
+          "minimum": 0,
+          "maximum": 200,
+          "examples": [80, 70, 90]
+        },
+        "percentageOf": {
+          "title": "Percentage Of",
+          "description": "Reference for percentage (e.g., '1RM', '5RM')",
+          "type": "string",
+          "maxLength": 50,
+          "examples": ["1RM", "5RM", "10RM"]
+        },
+        "targetRPE": {
+          "title": "Target RPE",
+          "description": "Target Rate of Perceived Exertion (0-10)",
+          "type": "number",
+          "minimum": 0,
+          "maximum": 10,
+          "examples": [7, 8, 9]
+        },
+        "targetRIR": {
+          "title": "Target RIR",
+          "description": "Target Reps In Reserve",
+          "type": "integer",
+          "minimum": 0,
+          "examples": [2, 3, 1]
+        },
+        "restSeconds": {
+          "title": "Rest (seconds)",
+          "description": "Recommended rest after this set",
+          "type": "integer",
+          "minimum": 0,
+          "examples": [90, 180, 60]
+        },
+        "tempo": {
+          "title": "Tempo",
+          "description": "Tempo notation: eccentric-pause-concentric-pause",
+          "type": "string",
+          "pattern": "^[0-9X]-[0-9X]-[0-9X]-[0-9X]$",
+          "examples": ["3-1-2-0", "4-0-1-0", "2-0-X-0"]
+        },
+        "type": {
+          "title": "Type",
+          "description": "Set type (working, warmup, dropset, etc.)",
+          "type": "string",
+          "maxLength": 50,
+          "examples": ["working", "warmup", "dropset"]
+        },
+        "notes": {
+          "title": "Notes",
+          "description": "Notes for this set",
+          "type": "string",
+          "maxLength": 1000
+        }
+      }
+    }
+  }
+}

--- a/scripts/validate-examples.js
+++ b/scripts/validate-examples.js
@@ -1,53 +1,132 @@
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
-import { readFileSync, readdirSync } from 'fs';
+import { readFileSync, readdirSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = join(__dirname, '..');
 
-const ajv = new Ajv({ allErrors: true });
-addFormats(ajv);
+function loadSchema(name) {
+  const schemaPath = join(rootDir, 'schemas', `${name}.schema.json`);
+  return JSON.parse(readFileSync(schemaPath, 'utf-8'));
+}
 
-const schemaPath = join(rootDir, 'schemas', 'workout-log.schema.json');
-const schema = JSON.parse(readFileSync(schemaPath, 'utf-8'));
-const validate = ajv.compile(schema);
+function createValidators() {
+  const ajv = new Ajv({ allErrors: true });
+  addFormats(ajv);
 
-const validDir = join(rootDir, 'examples', 'workout-logs');
-const invalidDir = join(rootDir, 'examples', 'invalid');
+  // Load workout-template schema first (referenced by program)
+  const templateSchema = loadSchema('workout-template');
+  ajv.addSchema(templateSchema);
+
+  // Load workout-log schema
+  const workoutLogSchema = loadSchema('workout-log');
+
+  // Load program schema
+  const programSchema = loadSchema('program');
+
+  return {
+    'workout-log': ajv.compile(workoutLogSchema),
+    'workout-template': ajv.compile(templateSchema),
+    'program': ajv.compile(programSchema)
+  };
+}
+
+const validators = createValidators();
 
 let exitCode = 0;
 
-console.log('Validating valid examples...\n');
+// Validate workout-logs
+const workoutLogsDir = join(rootDir, 'examples', 'workout-logs');
+console.log('Validating workout-logs...\n');
 
-const validFiles = readdirSync(validDir).filter(f => f.endsWith('.json'));
-for (const file of validFiles) {
-  const filePath = join(validDir, file);
+const workoutLogFiles = readdirSync(workoutLogsDir).filter(f => f.endsWith('.json'));
+for (const file of workoutLogFiles) {
+  const filePath = join(workoutLogsDir, file);
   const data = JSON.parse(readFileSync(filePath, 'utf-8'));
-  const valid = validate(data);
+  const valid = validators['workout-log'](data);
 
   if (valid) {
     console.log(`✓ ${file}`);
   } else {
     console.log(`✗ ${file} - SHOULD BE VALID`);
-    console.log(`  Errors: ${JSON.stringify(validate.errors, null, 2)}`);
+    console.log(`  Errors: ${JSON.stringify(validators['workout-log'].errors, null, 2)}`);
     exitCode = 1;
   }
 }
 
+// Validate workout-templates
+const templatesDir = join(rootDir, 'examples', 'workout-templates');
+if (existsSync(templatesDir)) {
+  console.log('\nValidating workout-templates...\n');
+
+  const templateFiles = readdirSync(templatesDir).filter(f => f.endsWith('.json'));
+  for (const file of templateFiles) {
+    const filePath = join(templatesDir, file);
+    const data = JSON.parse(readFileSync(filePath, 'utf-8'));
+    const valid = validators['workout-template'](data);
+
+    if (valid) {
+      console.log(`✓ ${file}`);
+    } else {
+      console.log(`✗ ${file} - SHOULD BE VALID`);
+      console.log(`  Errors: ${JSON.stringify(validators['workout-template'].errors, null, 2)}`);
+      exitCode = 1;
+    }
+  }
+}
+
+// Validate programs
+const programsDir = join(rootDir, 'examples', 'programs');
+if (existsSync(programsDir)) {
+  console.log('\nValidating programs...\n');
+
+  const programFiles = readdirSync(programsDir).filter(f => f.endsWith('.json'));
+  for (const file of programFiles) {
+    const filePath = join(programsDir, file);
+    const data = JSON.parse(readFileSync(filePath, 'utf-8'));
+    const valid = validators['program'](data);
+
+    if (valid) {
+      console.log(`✓ ${file}`);
+    } else {
+      console.log(`✗ ${file} - SHOULD BE VALID`);
+      console.log(`  Errors: ${JSON.stringify(validators['program'].errors, null, 2)}`);
+      exitCode = 1;
+    }
+  }
+}
+
+// Validate invalid examples
+const invalidDir = join(rootDir, 'examples', 'invalid');
 console.log('\nValidating invalid examples (should fail)...\n');
 
 const invalidFiles = readdirSync(invalidDir).filter(f => f.endsWith('.json'));
 for (const file of invalidFiles) {
   const filePath = join(invalidDir, file);
   const data = JSON.parse(readFileSync(filePath, 'utf-8'));
-  const valid = validate(data);
+
+  // Determine which validator to use based on filename
+  let validator;
+  let schemaName;
+  if (file.startsWith('template-')) {
+    validator = validators['workout-template'];
+    schemaName = 'workout-template';
+  } else if (file.startsWith('program-')) {
+    validator = validators['program'];
+    schemaName = 'program';
+  } else {
+    validator = validators['workout-log'];
+    schemaName = 'workout-log';
+  }
+
+  const valid = validator(data);
 
   if (!valid) {
-    console.log(`✓ ${file} - correctly rejected`);
+    console.log(`✓ ${file} - correctly rejected (${schemaName})`);
   } else {
-    console.log(`✗ ${file} - SHOULD BE INVALID but passed`);
+    console.log(`✗ ${file} - SHOULD BE INVALID but passed (${schemaName})`);
     exitCode = 1;
   }
 }

--- a/test/program.test.js
+++ b/test/program.test.js
@@ -1,0 +1,302 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import { readFileSync, readdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, '..');
+
+function createValidator() {
+  const ajv = new Ajv({ allErrors: true });
+  addFormats(ajv);
+
+  // Load and add the workout-template schema first (referenced by program schema)
+  const templateSchemaPath = join(rootDir, 'schemas', 'workout-template.schema.json');
+  const templateSchema = JSON.parse(readFileSync(templateSchemaPath, 'utf-8'));
+  ajv.addSchema(templateSchema);
+
+  // Load the program schema
+  const programSchemaPath = join(rootDir, 'schemas', 'program.schema.json');
+  const programSchema = JSON.parse(readFileSync(programSchemaPath, 'utf-8'));
+  return ajv.compile(programSchema);
+}
+
+describe('program schema', () => {
+  const validate = createValidator();
+
+  describe('valid examples', () => {
+    const validDir = join(rootDir, 'examples', 'programs');
+    const validFiles = readdirSync(validDir).filter(f => f.endsWith('.json'));
+
+    for (const file of validFiles) {
+      test(`${file} should be valid`, () => {
+        const filePath = join(validDir, file);
+        const data = JSON.parse(readFileSync(filePath, 'utf-8'));
+        const valid = validate(data);
+        assert.strictEqual(valid, true, `Validation errors: ${JSON.stringify(validate.errors)}`);
+      });
+    }
+  });
+
+  describe('invalid examples', () => {
+    const invalidDir = join(rootDir, 'examples', 'invalid');
+    const programInvalidFiles = readdirSync(invalidDir)
+      .filter(f => f.startsWith('program-') && f.endsWith('.json'));
+
+    for (const file of programInvalidFiles) {
+      test(`${file} should be invalid`, () => {
+        const filePath = join(invalidDir, file);
+        const data = JSON.parse(readFileSync(filePath, 'utf-8'));
+        const valid = validate(data);
+        assert.strictEqual(valid, false, `Expected ${file} to be invalid but it passed`);
+      });
+    }
+  });
+
+  describe('required fields', () => {
+    test('name is required', () => {
+      const data = {
+        weeks: [{
+          workouts: [{
+            name: 'Workout A',
+            exercises: [{ exercise: { name: 'Squat' }, sets: [{ targetReps: 5 }] }]
+          }]
+        }]
+      };
+      assert.strictEqual(validate(data), false);
+      assert.ok(validate.errors.some(e => e.params?.missingProperty === 'name'));
+    });
+
+    test('weeks array is required', () => {
+      const data = { name: 'Test Program' };
+      assert.strictEqual(validate(data), false);
+      assert.ok(validate.errors.some(e => e.params?.missingProperty === 'weeks'));
+    });
+
+    test('week.workouts is required', () => {
+      const data = {
+        name: 'Test Program',
+        weeks: [{ name: 'Week 1' }]
+      };
+      assert.strictEqual(validate(data), false);
+    });
+  });
+
+  describe('array constraints', () => {
+    test('weeks cannot be empty', () => {
+      const data = { name: 'Empty Program', weeks: [] };
+      assert.strictEqual(validate(data), false);
+    });
+
+    test('week.workouts cannot be empty', () => {
+      const data = {
+        name: 'Test Program',
+        weeks: [{ workouts: [] }]
+      };
+      assert.strictEqual(validate(data), false);
+    });
+  });
+
+  describe('program fields', () => {
+    test('description is valid', () => {
+      const data = {
+        name: 'Test Program',
+        description: 'A detailed description of the program',
+        weeks: [{
+          workouts: [{
+            name: 'Day 1',
+            exercises: [{ exercise: { name: 'Squat' }, sets: [{ targetReps: 5 }] }]
+          }]
+        }]
+      };
+      assert.strictEqual(validate(data), true);
+    });
+
+    test('author is valid', () => {
+      const data = {
+        name: 'Test Program',
+        author: 'John Doe',
+        weeks: [{
+          workouts: [{
+            name: 'Day 1',
+            exercises: [{ exercise: { name: 'Squat' }, sets: [{ targetReps: 5 }] }]
+          }]
+        }]
+      };
+      assert.strictEqual(validate(data), true);
+    });
+
+    test('tags array is valid', () => {
+      const data = {
+        name: 'Test Program',
+        tags: ['strength', 'beginner', 'powerlifting'],
+        weeks: [{
+          workouts: [{
+            name: 'Day 1',
+            exercises: [{ exercise: { name: 'Squat' }, sets: [{ targetReps: 5 }] }]
+          }]
+        }]
+      };
+      assert.strictEqual(validate(data), true);
+    });
+  });
+
+  describe('program week fields', () => {
+    test('week name is valid', () => {
+      const data = {
+        name: 'Test Program',
+        weeks: [{
+          name: 'Week 1 - Introduction',
+          workouts: [{
+            name: 'Day 1',
+            exercises: [{ exercise: { name: 'Squat' }, sets: [{ targetReps: 5 }] }]
+          }]
+        }]
+      };
+      assert.strictEqual(validate(data), true);
+    });
+
+    test('week notes are valid', () => {
+      const data = {
+        name: 'Test Program',
+        weeks: [{
+          notes: 'Focus on form this week',
+          workouts: [{
+            name: 'Day 1',
+            exercises: [{ exercise: { name: 'Squat' }, sets: [{ targetReps: 5 }] }]
+          }]
+        }]
+      };
+      assert.strictEqual(validate(data), true);
+    });
+  });
+
+  describe('multi-week programs', () => {
+    test('multiple weeks are valid', () => {
+      const data = {
+        name: '4-Week Program',
+        weeks: [
+          {
+            name: 'Week 1',
+            workouts: [{
+              name: 'Day 1',
+              exercises: [{ exercise: { name: 'Squat' }, sets: [{ targetReps: 5 }] }]
+            }]
+          },
+          {
+            name: 'Week 2',
+            workouts: [{
+              name: 'Day 1',
+              exercises: [{ exercise: { name: 'Squat' }, sets: [{ targetReps: 5 }] }]
+            }]
+          },
+          {
+            name: 'Week 3',
+            workouts: [{
+              name: 'Day 1',
+              exercises: [{ exercise: { name: 'Squat' }, sets: [{ targetReps: 3 }] }]
+            }]
+          },
+          {
+            name: 'Week 4 - Deload',
+            workouts: [{
+              name: 'Day 1',
+              exercises: [{ exercise: { name: 'Squat' }, sets: [{ targetReps: 5 }] }]
+            }]
+          }
+        ]
+      };
+      assert.strictEqual(validate(data), true);
+    });
+
+    test('multiple workouts per week are valid', () => {
+      const data = {
+        name: 'Full Body 3x/Week',
+        weeks: [{
+          workouts: [
+            {
+              name: 'Monday',
+              day: 1,
+              exercises: [{ exercise: { name: 'Squat' }, sets: [{ targetReps: 5 }] }]
+            },
+            {
+              name: 'Wednesday',
+              day: 3,
+              exercises: [{ exercise: { name: 'Bench Press' }, sets: [{ targetReps: 5 }] }]
+            },
+            {
+              name: 'Friday',
+              day: 5,
+              exercises: [{ exercise: { name: 'Deadlift' }, sets: [{ targetReps: 5 }] }]
+            }
+          ]
+        }]
+      };
+      assert.strictEqual(validate(data), true);
+    });
+  });
+
+  describe('workout template validation in program', () => {
+    test('workout templates are validated', () => {
+      const data = {
+        name: 'Test Program',
+        weeks: [{
+          workouts: [{
+            name: 'Day 1',
+            exercises: [{ exercise: { name: 'Squat' }, sets: [] }] // Empty sets should fail
+          }]
+        }]
+      };
+      assert.strictEqual(validate(data), false);
+    });
+
+    test('targetWeight requires unit in program workouts', () => {
+      const data = {
+        name: 'Test Program',
+        weeks: [{
+          workouts: [{
+            name: 'Day 1',
+            exercises: [{
+              exercise: { name: 'Squat' },
+              sets: [{ targetWeight: 100 }] // Missing unit
+            }]
+          }]
+        }]
+      };
+      assert.strictEqual(validate(data), false);
+    });
+  });
+
+  describe('extensibility', () => {
+    test('additionalProperties are allowed at program level', () => {
+      const data = {
+        name: 'Test Program',
+        'app:programId': 'abc123',
+        weeks: [{
+          workouts: [{
+            name: 'Day 1',
+            exercises: [{ exercise: { name: 'Squat' }, sets: [{ targetReps: 5 }] }]
+          }]
+        }]
+      };
+      assert.strictEqual(validate(data), true);
+    });
+
+    test('additionalProperties are allowed at week level', () => {
+      const data = {
+        name: 'Test Program',
+        weeks: [{
+          'app:weekNumber': 1,
+          workouts: [{
+            name: 'Day 1',
+            exercises: [{ exercise: { name: 'Squat' }, sets: [{ targetReps: 5 }] }]
+          }]
+        }]
+      };
+      assert.strictEqual(validate(data), true);
+    });
+  });
+});

--- a/test/workout-template.test.js
+++ b/test/workout-template.test.js
@@ -1,0 +1,288 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import { readFileSync, readdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, '..');
+
+function createValidator() {
+  const ajv = new Ajv({ allErrors: true });
+  addFormats(ajv);
+  const schemaPath = join(rootDir, 'schemas', 'workout-template.schema.json');
+  const schema = JSON.parse(readFileSync(schemaPath, 'utf-8'));
+  return ajv.compile(schema);
+}
+
+describe('workout-template schema', () => {
+  const validate = createValidator();
+
+  describe('valid examples', () => {
+    const validDir = join(rootDir, 'examples', 'workout-templates');
+    const validFiles = readdirSync(validDir).filter(f => f.endsWith('.json'));
+
+    for (const file of validFiles) {
+      test(`${file} should be valid`, () => {
+        const filePath = join(validDir, file);
+        const data = JSON.parse(readFileSync(filePath, 'utf-8'));
+        const valid = validate(data);
+        assert.strictEqual(valid, true, `Validation errors: ${JSON.stringify(validate.errors)}`);
+      });
+    }
+  });
+
+  describe('invalid examples', () => {
+    const invalidDir = join(rootDir, 'examples', 'invalid');
+    const templateInvalidFiles = readdirSync(invalidDir)
+      .filter(f => f.startsWith('template-') && f.endsWith('.json'));
+
+    for (const file of templateInvalidFiles) {
+      test(`${file} should be invalid`, () => {
+        const filePath = join(invalidDir, file);
+        const data = JSON.parse(readFileSync(filePath, 'utf-8'));
+        const valid = validate(data);
+        assert.strictEqual(valid, false, `Expected ${file} to be invalid but it passed`);
+      });
+    }
+  });
+
+  describe('required fields', () => {
+    test('name is required', () => {
+      const data = {
+        exercises: [{ exercise: { name: 'Squat' }, sets: [{ targetReps: 5 }] }]
+      };
+      assert.strictEqual(validate(data), false);
+      assert.ok(validate.errors.some(e => e.params?.missingProperty === 'name'));
+    });
+
+    test('exercises array is required', () => {
+      const data = { name: 'Test Template' };
+      assert.strictEqual(validate(data), false);
+      assert.ok(validate.errors.some(e => e.params?.missingProperty === 'exercises'));
+    });
+
+    test('exercise.name is required', () => {
+      const data = {
+        name: 'Test Template',
+        exercises: [{ exercise: {}, sets: [{ targetReps: 5 }] }]
+      };
+      assert.strictEqual(validate(data), false);
+    });
+
+    test('sets array is required in exercise template', () => {
+      const data = {
+        name: 'Test Template',
+        exercises: [{ exercise: { name: 'Squat' } }]
+      };
+      assert.strictEqual(validate(data), false);
+    });
+  });
+
+  describe('array constraints', () => {
+    test('exercises cannot be empty', () => {
+      const data = { name: 'Empty Template', exercises: [] };
+      assert.strictEqual(validate(data), false);
+    });
+
+    test('sets cannot be empty', () => {
+      const data = {
+        name: 'Test Template',
+        exercises: [{ exercise: { name: 'Squat' }, sets: [] }]
+      };
+      assert.strictEqual(validate(data), false);
+    });
+  });
+
+  describe('set template fields', () => {
+    test('targetReps is valid', () => {
+      const data = {
+        name: 'Test',
+        exercises: [{
+          exercise: { name: 'Squat' },
+          sets: [{ targetReps: 5 }]
+        }]
+      };
+      assert.strictEqual(validate(data), true);
+    });
+
+    test('rep range (targetRepsMin/Max) is valid', () => {
+      const data = {
+        name: 'Test',
+        exercises: [{
+          exercise: { name: 'Squat' },
+          sets: [{ targetRepsMin: 8, targetRepsMax: 12 }]
+        }]
+      };
+      assert.strictEqual(validate(data), true);
+    });
+
+    test('targetWeight requires unit', () => {
+      const data = {
+        name: 'Test',
+        exercises: [{
+          exercise: { name: 'Squat' },
+          sets: [{ targetWeight: 100 }]
+        }]
+      };
+      assert.strictEqual(validate(data), false);
+    });
+
+    test('targetWeight with unit is valid', () => {
+      const data = {
+        name: 'Test',
+        exercises: [{
+          exercise: { name: 'Squat' },
+          sets: [{ targetWeight: 100, unit: 'kg' }]
+        }]
+      };
+      assert.strictEqual(validate(data), true);
+    });
+
+    test('percentage requires percentageOf', () => {
+      const data = {
+        name: 'Test',
+        exercises: [{
+          exercise: { name: 'Squat' },
+          sets: [{ percentage: 85 }]
+        }]
+      };
+      assert.strictEqual(validate(data), false);
+    });
+
+    test('percentage with percentageOf is valid', () => {
+      const data = {
+        name: 'Test',
+        exercises: [{
+          exercise: { name: 'Squat' },
+          sets: [{ percentage: 85, percentageOf: '1RM' }]
+        }]
+      };
+      assert.strictEqual(validate(data), true);
+    });
+
+    test('targetRPE must be between 0 and 10', () => {
+      const data = {
+        name: 'Test',
+        exercises: [{
+          exercise: { name: 'Squat' },
+          sets: [{ targetReps: 5, targetRPE: 11 }]
+        }]
+      };
+      assert.strictEqual(validate(data), false);
+    });
+
+    test('targetRPE allows decimals', () => {
+      const data = {
+        name: 'Test',
+        exercises: [{
+          exercise: { name: 'Squat' },
+          sets: [{ targetReps: 5, targetRPE: 7.5 }]
+        }]
+      };
+      assert.strictEqual(validate(data), true);
+    });
+
+    test('tempo must match pattern', () => {
+      const data = {
+        name: 'Test',
+        exercises: [{
+          exercise: { name: 'Squat' },
+          sets: [{ targetReps: 5, tempo: '3-1-2-0' }]
+        }]
+      };
+      assert.strictEqual(validate(data), true);
+    });
+
+    test('invalid tempo format is rejected', () => {
+      const data = {
+        name: 'Test',
+        exercises: [{
+          exercise: { name: 'Squat' },
+          sets: [{ targetReps: 5, tempo: '3110' }]
+        }]
+      };
+      assert.strictEqual(validate(data), false);
+    });
+  });
+
+  describe('day field', () => {
+    test('day must be between 1 and 7', () => {
+      const data = {
+        name: 'Test',
+        day: 8,
+        exercises: [{ exercise: { name: 'Squat' }, sets: [{ targetReps: 5 }] }]
+      };
+      assert.strictEqual(validate(data), false);
+    });
+
+    test('day 0 is invalid', () => {
+      const data = {
+        name: 'Test',
+        day: 0,
+        exercises: [{ exercise: { name: 'Squat' }, sets: [{ targetReps: 5 }] }]
+      };
+      assert.strictEqual(validate(data), false);
+    });
+
+    test('day 1-7 are valid', () => {
+      for (let day = 1; day <= 7; day++) {
+        const data = {
+          name: 'Test',
+          day,
+          exercises: [{ exercise: { name: 'Squat' }, sets: [{ targetReps: 5 }] }]
+        };
+        assert.strictEqual(validate(data), true, `Day ${day} should be valid`);
+      }
+    });
+  });
+
+  describe('superset support', () => {
+    test('supersetId groups exercises', () => {
+      const data = {
+        name: 'Superset Test',
+        exercises: [
+          { exercise: { name: 'Bench Press' }, supersetId: 1, sets: [{ targetReps: 10 }] },
+          { exercise: { name: 'Bent Over Row' }, supersetId: 1, sets: [{ targetReps: 10 }] }
+        ]
+      };
+      assert.strictEqual(validate(data), true);
+    });
+
+    test('supersetId must be at least 1', () => {
+      const data = {
+        name: 'Test',
+        exercises: [{
+          exercise: { name: 'Squat' },
+          supersetId: 0,
+          sets: [{ targetReps: 5 }]
+        }]
+      };
+      assert.strictEqual(validate(data), false);
+    });
+  });
+
+  describe('extensibility', () => {
+    test('additionalProperties are allowed at root', () => {
+      const data = {
+        name: 'Test',
+        exercises: [{ exercise: { name: 'Squat' }, sets: [{ targetReps: 5 }] }],
+        'app:templateId': 'abc123'
+      };
+      assert.strictEqual(validate(data), true);
+    });
+
+    test('additionalProperties are allowed on set template', () => {
+      const data = {
+        name: 'Test',
+        exercises: [{
+          exercise: { name: 'Squat' },
+          sets: [{ targetReps: 5, 'app:videoDemo': 'https://example.com' }]
+        }]
+      };
+      assert.strictEqual(validate(data), true);
+    });
+  });
+});


### PR DESCRIPTION
Schemas:
- workout-template.schema.json: WorkoutTemplate with ExerciseTemplate and SetTemplate definitions (targetReps, percentage-based weights, rep ranges, RPE/RIR targets)
- program.schema.json: Program with ProgramWeek, referencing workout-template schema
- workout-log.schema.json: Add optional templateId field

TypeScript SDK:
- New types: WorkoutTemplate, ExerciseTemplate, SetTemplate, Program, ProgramWeek
- New functions: parseWorkoutTemplate, parseProgram, serializeWorkoutTemplate, serializeProgram, validateWorkoutTemplate, validateProgram, isValidWorkoutTemplate, isValidProgram
- Export new schemas: workoutTemplateSchema, programSchema

Examples:
- workout-templates/: minimal, full-featured, percentage-based
- programs/: minimal, 531-bbb (full 4-week 5/3/1 BBB program)
- invalid/: template and program validation test cases

Tests:
- 93 schema tests (34 template, 25 program, 34 workout-log)
- 55 SDK tests (24 new for templates/programs)

