### PR TITLE
feat: Add automated versioning with Conventional Commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

Fixes two issues with the automated release workflow:

1. **False positive breaking change detection** - The commit body contained `feat!:` as documentation text, which triggered a major version bump (0.1.2 → 1.0.0). Now only checks the first line of the commit message.

2. **Branch protection blocks version commits** - Can't push version file updates to main. Now sets version from git tag at publish time instead of committing to main.

## Changes

**release.yml:**
- Only check first line of commit for version type detection
- Remove version file update/commit steps (no longer needed)

**publish.yml:**
- Add "Set version from tag" step for both npm and Maven
- Version is extracted from `GITHUB_REF` (e.g., `refs/tags/v0.2.0` → `0.2.0`)

## Test plan

- [ ] Merge this PR with squash (title starts with `fix:`)
- [ ] Verify release workflow detects PATCH bump (0.1.2 → 0.1.3)
- [ ] Verify tag v0.1.3 is created
- [ ] Verify publish workflow sets correct version from tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)