### PR TITLE
docs: Update documentation for v0.2.0 release

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -92,7 +92,15 @@ const pretty = serializeWorkoutLogPretty(workout)
 
 ## Kotlin SDK
 
-For Android/JVM projects, see the [Kotlin SDK documentation](/sdk/kotlin).
+For Android/JVM projects, add the Maven Central dependency:
+
+```kotlin
+dependencies {
+    implementation("io.github.radupana:openweight-sdk:0.2.0")
+}
+```
+
+See the full [Kotlin SDK documentation](/sdk/kotlin) for parsing, validation, and serialization examples.
 
 ## Next Steps
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -29,13 +29,14 @@ openweight provides:
 4. **SDK-driven** — Apps integrate via SDKs, not by hand-rolling JSON
 5. **Extensible** — Optional fields and extension namespaces for app-specific data
 
-## Three Core Schemas
+## Four Core Schemas
 
 | Schema              | Purpose                                                  |
 |---------------------|----------------------------------------------------------|
 | **WorkoutLog**      | A completed workout session with actual performance data |
 | **WorkoutTemplate** | A planned workout with target reps, weights, and RPE     |
 | **Program**         | A multi-week training program containing templates       |
+| **PersonalRecords** | Personal records and one-rep maxes for data portability  |
 
 ## Next Steps
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,10 +16,10 @@ hero:
 features:
   - icon: 📋
     title: JSON Schema Spec
-    details: A clean, well-documented schema for workouts, templates, and programs. Human-readable and machine-validatable.
+    details: A clean, well-documented schema for workouts, templates, programs, and personal records. Human-readable and machine-validatable.
   - icon: 🔧
     title: Ready-to-Use SDKs
-    details: TypeScript and Kotlin SDKs for parsing, validating, and serializing workout data. Integrate in minutes.
+    details: TypeScript (npm) and Kotlin (Maven Central) SDKs for parsing, validating, and serializing workout data. Integrate in minutes.
   - icon: 🔄
     title: Data Portability
     details: Export from one app, import to another. No vendor lock-in, no proprietary formats.

--- a/docs/sdk/index.md
+++ b/docs/sdk/index.md
@@ -5,10 +5,10 @@ applications.
 
 ## Available SDKs
 
-| SDK                           | Package           | Platform          |
-|-------------------------------|-------------------|-------------------|
-| [TypeScript](/sdk/typescript) | `@openweight/sdk` | Node.js, Browsers |
-| [Kotlin](/sdk/kotlin)         | `com.openweight`  | Android, JVM      |
+| SDK                           | Package                              | Platform          |
+|-------------------------------|--------------------------------------|-------------------|
+| [TypeScript](/sdk/typescript) | `@openweight/sdk`                    | Node.js, Browsers |
+| [Kotlin](/sdk/kotlin)         | `io.github.radupana:openweight-sdk`  | Android, JVM      |
 
 ## Shared Patterns
 
@@ -131,10 +131,11 @@ try {
 
 ## Supported Types
 
-Both SDKs support all three schema types:
+Both SDKs support all four schema types:
 
-| Type            | Parse                  | Validate                  | Serialize                  |
-|-----------------|------------------------|---------------------------|----------------------------|
-| WorkoutLog      | `parseWorkoutLog`      | `validateWorkoutLog`      | `serializeWorkoutLog`      |
-| WorkoutTemplate | `parseWorkoutTemplate` | `validateWorkoutTemplate` | `serializeWorkoutTemplate` |
-| Program         | `parseProgram`         | `validateProgram`         | `serializeProgram`         |
+| Type            | Parse                   | Validate                   | Serialize                   |
+|-----------------|-------------------------|----------------------------|-----------------------------|
+| WorkoutLog      | `parseWorkoutLog`       | `validateWorkoutLog`       | `serializeWorkoutLog`       |
+| WorkoutTemplate | `parseWorkoutTemplate`  | `validateWorkoutTemplate`  | `serializeWorkoutTemplate`  |
+| Program         | `parseProgram`          | `validateProgram`          | `serializeProgram`          |
+| PersonalRecords | `parsePersonalRecords`  | `validatePersonalRecords`  | `serializePersonalRecords`  |

--- a/docs/sdk/kotlin.md
+++ b/docs/sdk/kotlin.md
@@ -7,14 +7,20 @@ The Kotlin SDK provides type-safe parsing, validation, and serialization for ope
 Add the dependency to your `build.gradle.kts`:
 
 ```kotlin
+repositories {
+    mavenCentral()
+}
+
 dependencies {
-    implementation("com.openweight:openweight-sdk:0.1.0")
+    implementation("io.github.radupana:openweight-sdk:0.2.0")
 }
 ```
 
-::: warning Not Yet Published
-The Kotlin SDK is not yet published to Maven Central. For now, you must include the source directly from the [openweight repository](https://github.com/radupana/openweight/tree/main/packages/kotlin-sdk).
-:::
+For Gradle (Groovy):
+
+```groovy
+implementation 'io.github.radupana:openweight-sdk:0.2.0'
+```
 
 ## Requirements
 


### PR DESCRIPTION
## Summary

Updates documentation to reflect v0.2.0 release and Kotlin SDK availability on Maven Central.

## Changes

**docs/sdk/kotlin.md:**
- Remove "Not Yet Published" warning
- Update package name from `com.openweight:openweight-sdk:0.1.0` to `io.github.radupana:openweight-sdk:0.2.0`
- Add Gradle Groovy syntax example

**docs/sdk/index.md:**
- Fix Kotlin package name in SDK table
- Add PersonalRecords to supported types table (now shows all 4 types)

**docs/guide/index.md:**
- Update "Three Core Schemas" → "Four Core Schemas"
- Add PersonalRecords to the table

**docs/guide/getting-started.md:**
- Add Kotlin Maven Central dependency example

**docs/index.md:**
- Update features to mention "personal records" in schema description
- Note that both SDKs are available (npm + Maven Central)

## Test plan

- [ ] Verify docs build: `cd docs && npm run docs:build`
- [ ] Check Kotlin SDK page no longer shows warning
- [ ] Verify all version references show 0.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)