### PR TITLE
fix: Use RELEASE_PAT for GitHub release to trigger Publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,7 +179,9 @@ jobs:
           draft: false
           prerelease: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use RELEASE_PAT instead of GITHUB_TOKEN so the release event
+          # triggers the Publish workflow (GITHUB_TOKEN doesn't trigger workflows)
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
 
       - name: Set outputs
         id: release


### PR DESCRIPTION
## Summary

- Fix Publish workflow not triggering after release creation

## Problem

The Publish workflow (`publish.yml`) triggers on `release: types: [published]`, but it wasn't running after v0.3.0 was released. The last successful Publish run was for v0.2.0 on Nov 30th.

**Root cause**: The release was being created using `GITHUB_TOKEN`. GitHub Actions intentionally doesn't trigger workflows from events created by `GITHUB_TOKEN` to prevent infinite loops.

## Solution

Use `RELEASE_PAT` (which already exists in the repo secrets and is used for checkout) instead of `GITHUB_TOKEN` when creating the GitHub release. This allows the release event to properly trigger the Publish workflow.

## Verification

After merging, the next `feat`/`fix`/`perf`/`refactor` commit to main should:
1. Trigger Release workflow → create a new release
2. The release should trigger Publish workflow → publish to npm and Maven Central

## Note on v0.3.0

v0.3.0 was already released but not published. After this fix is merged, you may want to manually trigger the Publish workflow or delete/recreate the v0.3.0 release to publish it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)