### PR TITLE
feat: Add target fields to SetLog for programmed workouts (#60)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.md
 !README.md
 !VISION.md
+!CONTRIBUTING.md
 !docs/**/*.md
 node_modules/
 dist/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,124 @@
+# Contributing to openweight
+
+Thank you for your interest in contributing to openweight!
+
+## Development Setup
+
+### Prerequisites
+
+- Node.js 18+
+- JDK 21+ (for Kotlin SDK)
+
+### Getting Started
+
+```bash
+# Clone the repository
+git clone https://github.com/radupana/openweight.git
+cd openweight
+
+# Install dependencies
+npm install
+
+# Build all packages
+npm run build
+
+# Run tests
+npm test
+```
+
+## Project Structure
+
+```
+schemas/              # JSON Schema files (source of truth)
+packages/
+  ts-sdk/             # TypeScript SDK
+  kotlin-sdk/         # Kotlin SDK
+docs/                 # VitePress documentation site
+examples/             # Example JSON files
+  workout-logs/
+  workout-templates/
+  programs/
+  lifter-profiles/
+  invalid/            # Invalid examples for testing
+```
+
+## Making Changes
+
+### Schema Changes
+
+1. Edit the relevant schema in `schemas/`
+2. Add or update example files in `examples/`
+3. Run `npm run validate-examples` to verify
+4. Update SDK types and tests in both TypeScript and Kotlin SDKs
+5. Update documentation in `docs/`
+
+### SDK Changes
+
+**TypeScript:**
+
+```bash
+cd packages/ts-sdk
+npm test
+npm run build
+```
+
+**Kotlin:**
+
+```bash
+cd packages/kotlin-sdk
+./gradlew test
+./gradlew build
+```
+
+### Documentation Changes
+
+```bash
+cd docs
+npm run dev      # Local dev server
+npm run build    # Production build
+```
+
+## Commit Messages
+
+We use [Conventional Commits](https://www.conventionalcommits.org/). PR titles must follow this format:
+
+- `feat:` - New features (triggers minor version bump)
+- `fix:` - Bug fixes (triggers patch version bump)
+- `feat!:` or `BREAKING CHANGE:` - Breaking changes (triggers major version bump)
+- `docs:` - Documentation only
+- `chore:` - Maintenance tasks
+- `refactor:` - Code refactoring
+- `test:` - Test changes
+
+Examples:
+- `feat: Add bodyweight tracking to LifterProfile`
+- `fix: Handle missing unit in RepMax validation`
+- `docs: Update TypeScript SDK examples`
+
+## Pull Requests
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/my-feature`)
+3. Make your changes
+4. Ensure tests pass (`npm test`)
+5. Commit with a conventional commit message
+6. Push to your fork
+7. Open a pull request
+
+## Code Style
+
+- **TypeScript:** Follow existing patterns, use TypeScript strict mode
+- **Kotlin:** Follow Kotlin coding conventions
+- **Schemas:** Include `title` and `description` for all fields
+
+## Testing
+
+All changes should include appropriate tests:
+
+- Schema validation tests for new fields
+- SDK unit tests for new functions
+- Example files for new features
+
+## Questions?
+
+Open an issue for discussion before making large changes.

--- a/README.md
+++ b/README.md
@@ -80,12 +80,10 @@ console.log(log.exercises[0].exercise.name); // "Squat"
 **Kotlin/JVM:**
 
 ```kotlin
-implementation("io.github.radupana:openweight-sdk:0.2.0")
+implementation("io.github.radupana:openweight-sdk:0.4.0")
 ```
 
 ```kotlin
-import org.openweight.sdk.parseWorkoutLog
-
 val log = parseWorkoutLog(jsonString)
 println(log.exercises[0].exercise.name) // "Squat"
 ```

--- a/examples/invalid/target-weight-without-unit.json
+++ b/examples/invalid/target-weight-without-unit.json
@@ -1,0 +1,16 @@
+{
+  "date": "2024-01-20T09:00:00Z",
+  "exercises": [
+    {
+      "exercise": {
+        "name": "Bench Press"
+      },
+      "sets": [
+        {
+          "reps": 5,
+          "targetWeight": 100
+        }
+      ]
+    }
+  ]
+}

--- a/examples/workout-logs/programmed-workout.json
+++ b/examples/workout-logs/programmed-workout.json
@@ -1,0 +1,78 @@
+{
+  "date": "2024-01-20T09:00:00Z",
+  "name": "Week 3 Day 1 - Squat",
+  "templateId": "531-squat-day",
+  "durationSeconds": 3600,
+  "exercises": [
+    {
+      "exercise": {
+        "name": "Barbell Back Squat",
+        "equipment": "barbell",
+        "category": "legs"
+      },
+      "sets": [
+        {
+          "reps": 5,
+          "weight": 60,
+          "unit": "kg",
+          "type": "warmup",
+          "targetReps": 5,
+          "targetWeight": 60,
+          "targetRPE": 5
+        },
+        {
+          "reps": 5,
+          "weight": 95,
+          "unit": "kg",
+          "rpe": 7,
+          "targetReps": 5,
+          "targetWeight": 95,
+          "targetRPE": 7
+        },
+        {
+          "reps": 3,
+          "weight": 107.5,
+          "unit": "kg",
+          "rpe": 8,
+          "targetReps": 3,
+          "targetWeight": 107.5,
+          "targetRPE": 8
+        },
+        {
+          "reps": 2,
+          "weight": 120,
+          "unit": "kg",
+          "rpe": 9,
+          "targetReps": 1,
+          "targetWeight": 120,
+          "targetRPE": 9
+        }
+      ]
+    },
+    {
+      "exercise": {
+        "name": "Paused Squat",
+        "equipment": "barbell",
+        "category": "legs"
+      },
+      "sets": [
+        {
+          "reps": 5,
+          "weight": 80,
+          "unit": "kg",
+          "rpe": 7.5,
+          "targetReps": 5,
+          "targetRPE": 7
+        },
+        {
+          "reps": 5,
+          "weight": 80,
+          "unit": "kg",
+          "rpe": 8,
+          "targetReps": 5,
+          "targetRPE": 7
+        }
+      ]
+    }
+  ]
+}

--- a/packages/kotlin-sdk/build.gradle.kts
+++ b/packages/kotlin-sdk/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "io.github.radupana"
-version = "0.3.1"
+version = "0.4.0"
 
 mavenPublishing {
     publishToMavenCentral(com.vanniktech.maven.publish.SonatypeHost.CENTRAL_PORTAL)

--- a/packages/kotlin-sdk/src/main/kotlin/com/openweight/model/SetLog.kt
+++ b/packages/kotlin-sdk/src/main/kotlin/com/openweight/model/SetLog.kt
@@ -16,5 +16,8 @@ data class SetLog(
     val type: String? = null,
     val restSeconds: Int? = null,
     val tempo: String? = null,
-    val notes: String? = null
+    val notes: String? = null,
+    val targetReps: Int? = null,
+    val targetWeight: Double? = null,
+    val targetRPE: Double? = null
 )

--- a/packages/kotlin-sdk/src/test/kotlin/com/openweight/ExampleFilesTest.kt
+++ b/packages/kotlin-sdk/src/test/kotlin/com/openweight/ExampleFilesTest.kt
@@ -25,7 +25,8 @@ class ExampleFilesTest {
         "timed-exercises",
         "carries-and-distance",
         "tempo-training",
-        "bodyweight-workout"
+        "bodyweight-workout",
+        "programmed-workout"
     ])
     fun `valid workout-log examples`(filename: String) {
         val json = loadResource("/examples/workout-logs/$filename.json")
@@ -65,7 +66,8 @@ class ExampleFilesTest {
         "empty-sets",
         "weight-without-unit",
         "distance-without-unit",
-        "invalid-unit"
+        "invalid-unit",
+        "target-weight-without-unit"
     ])
     fun `invalid workout-log examples`(filename: String) {
         val json = loadResource("/examples/invalid/$filename.json")

--- a/packages/kotlin-sdk/src/test/resources/examples/invalid/target-weight-without-unit.json
+++ b/packages/kotlin-sdk/src/test/resources/examples/invalid/target-weight-without-unit.json
@@ -1,0 +1,16 @@
+{
+  "date": "2024-01-20T09:00:00Z",
+  "exercises": [
+    {
+      "exercise": {
+        "name": "Bench Press"
+      },
+      "sets": [
+        {
+          "reps": 5,
+          "targetWeight": 100
+        }
+      ]
+    }
+  ]
+}

--- a/packages/kotlin-sdk/src/test/resources/examples/workout-logs/programmed-workout.json
+++ b/packages/kotlin-sdk/src/test/resources/examples/workout-logs/programmed-workout.json
@@ -1,0 +1,78 @@
+{
+  "date": "2024-01-20T09:00:00Z",
+  "name": "Week 3 Day 1 - Squat",
+  "templateId": "531-squat-day",
+  "durationSeconds": 3600,
+  "exercises": [
+    {
+      "exercise": {
+        "name": "Barbell Back Squat",
+        "equipment": "barbell",
+        "category": "legs"
+      },
+      "sets": [
+        {
+          "reps": 5,
+          "weight": 60,
+          "unit": "kg",
+          "type": "warmup",
+          "targetReps": 5,
+          "targetWeight": 60,
+          "targetRPE": 5
+        },
+        {
+          "reps": 5,
+          "weight": 95,
+          "unit": "kg",
+          "rpe": 7,
+          "targetReps": 5,
+          "targetWeight": 95,
+          "targetRPE": 7
+        },
+        {
+          "reps": 3,
+          "weight": 107.5,
+          "unit": "kg",
+          "rpe": 8,
+          "targetReps": 3,
+          "targetWeight": 107.5,
+          "targetRPE": 8
+        },
+        {
+          "reps": 2,
+          "weight": 120,
+          "unit": "kg",
+          "rpe": 9,
+          "targetReps": 1,
+          "targetWeight": 120,
+          "targetRPE": 9
+        }
+      ]
+    },
+    {
+      "exercise": {
+        "name": "Paused Squat",
+        "equipment": "barbell",
+        "category": "legs"
+      },
+      "sets": [
+        {
+          "reps": 5,
+          "weight": 80,
+          "unit": "kg",
+          "rpe": 7.5,
+          "targetReps": 5,
+          "targetRPE": 7
+        },
+        {
+          "reps": 5,
+          "weight": 80,
+          "unit": "kg",
+          "rpe": 8,
+          "targetReps": 5,
+          "targetRPE": 7
+        }
+      ]
+    }
+  ]
+}

--- a/packages/ts-sdk/package.json
+++ b/packages/ts-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openweight/sdk",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "TypeScript SDK for openweight - parse, validate, and serialize workout data",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/ts-sdk/src/schema.ts
+++ b/packages/ts-sdk/src/schema.ts
@@ -936,6 +936,18 @@ export const workoutLogSchema = {
               "distanceUnit"
             ]
           }
+        },
+        {
+          "if": {
+            "required": [
+              "targetWeight"
+            ]
+          },
+          "then": {
+            "required": [
+              "unit"
+            ]
+          }
         }
       ],
       "properties": {
@@ -1070,6 +1082,40 @@ export const workoutLogSchema = {
           "description": "Notes for this specific set",
           "type": "string",
           "maxLength": 1000
+        },
+        "targetReps": {
+          "title": "Target Reps",
+          "description": "Prescribed number of reps from a program or template",
+          "type": "integer",
+          "minimum": 0,
+          "examples": [
+            5,
+            8,
+            12
+          ]
+        },
+        "targetWeight": {
+          "title": "Target Weight",
+          "description": "Prescribed weight from a program or template",
+          "type": "number",
+          "minimum": 0,
+          "examples": [
+            100,
+            60.5,
+            225
+          ]
+        },
+        "targetRPE": {
+          "title": "Target RPE",
+          "description": "Prescribed Rate of Perceived Exertion from a program or template (0-10)",
+          "type": "number",
+          "minimum": 0,
+          "maximum": 10,
+          "examples": [
+            7,
+            8,
+            9
+          ]
         }
       }
     }

--- a/packages/ts-sdk/src/types.ts
+++ b/packages/ts-sdk/src/types.ts
@@ -20,6 +20,9 @@ export interface SetLog {
   restSeconds?: number
   tempo?: string
   notes?: string
+  targetReps?: number
+  targetWeight?: number
+  targetRPE?: number
   [key: string]: unknown
 }
 

--- a/packages/ts-sdk/src/validate.test.ts
+++ b/packages/ts-sdk/src/validate.test.ts
@@ -90,6 +90,54 @@ describe('validateWorkoutLog', () => {
     expect(result.valid).toBe(false)
   })
 
+  it('returns invalid when targetWeight is provided without unit', () => {
+    const result = validateWorkoutLog({
+      date: '2024-01-15T09:00:00Z',
+      exercises: [
+        {
+          exercise: { name: 'Squat' },
+          sets: [{ reps: 5, targetWeight: 100 }],
+        },
+      ],
+    })
+    expect(result.valid).toBe(false)
+  })
+
+  it('returns valid for target fields with unit', () => {
+    const result = validateWorkoutLog({
+      date: '2024-01-15T09:00:00Z',
+      exercises: [
+        {
+          exercise: { name: 'Squat' },
+          sets: [
+            {
+              reps: 5,
+              weight: 100,
+              unit: 'kg',
+              targetReps: 5,
+              targetWeight: 100,
+              targetRPE: 8,
+            },
+          ],
+        },
+      ],
+    })
+    expect(result.valid).toBe(true)
+  })
+
+  it('returns valid for targetReps alone without unit', () => {
+    const result = validateWorkoutLog({
+      date: '2024-01-15T09:00:00Z',
+      exercises: [
+        {
+          exercise: { name: 'Push-up' },
+          sets: [{ reps: 15, targetReps: 20 }],
+        },
+      ],
+    })
+    expect(result.valid).toBe(true)
+  })
+
   it('returns invalid for invalid unit enum', () => {
     const result = validateWorkoutLog({
       date: '2024-01-15T09:00:00Z',

--- a/schemas/workout-log.schema.json
+++ b/schemas/workout-log.schema.json
@@ -144,6 +144,10 @@
         {
           "if": { "required": ["distance"] },
           "then": { "required": ["distanceUnit"] }
+        },
+        {
+          "if": { "required": ["targetWeight"] },
+          "then": { "required": ["unit"] }
         }
       ],
       "properties": {
@@ -233,6 +237,28 @@
           "description": "Notes for this specific set",
           "type": "string",
           "maxLength": 1000
+        },
+        "targetReps": {
+          "title": "Target Reps",
+          "description": "Prescribed number of reps from a program or template",
+          "type": "integer",
+          "minimum": 0,
+          "examples": [5, 8, 12]
+        },
+        "targetWeight": {
+          "title": "Target Weight",
+          "description": "Prescribed weight from a program or template",
+          "type": "number",
+          "minimum": 0,
+          "examples": [100, 60.5, 225]
+        },
+        "targetRPE": {
+          "title": "Target RPE",
+          "description": "Prescribed Rate of Perceived Exertion from a program or template (0-10)",
+          "type": "number",
+          "minimum": 0,
+          "maximum": 10,
+          "examples": [7, 8, 9]
         }
       }
     }


### PR DESCRIPTION
  Add targetReps, targetWeight, and targetRPE optional fields to SetLog so workout exports can include prescribed targets from programs.